### PR TITLE
Update search.cpp

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -580,7 +580,7 @@ namespace {
     // search to overwrite a previous full search TT value, so we use a different
     // position key in case of an excluded move.
     excludedMove = ss->excludedMove;
-    posKey = pos.key() ^ Key(excludedMove << 16); // Isn't a very good hash
+    posKey = pos.key() ^ (Key(excludedMove) << 16); // Isn't a very good hash
     tte = TT.probe(posKey, ttHit);
     ttValue = ttHit ? value_from_tt(tte->value(), ss->ply) : VALUE_NONE;
     ttMove =  rootNode ? thisThread->rootMoves[thisThread->PVIdx].pv[0]


### PR DESCRIPTION
The current code first takes the 32 bit int excludedMove, shifts it to the left 16, then sign extends the shifted quantity to 64 bits. This is dumb. Why not just shift the unsigned quantity to the left 16?